### PR TITLE
Bug/empty profiles in UI

### DIFF
--- a/PVPWarn.toc
+++ b/PVPWarn.toc
@@ -3,7 +3,7 @@
 ## Author: Michael Wiesendanger <michael.wiesendanger@gmail.com>
 ## Notes: PVPWarn aims to warn players visually and acoustically about pvp events
 ## Version: v1.2.8
-## SavedVariablesPerCharacter: PVPWarnConfiguration PVPWarnLogTracker PVPWarnTestLog PVPWarnProfiles
+## SavedVariablesPerCharacter: PVPWarnConfiguration PVPWarnProfiles PVPWarnLogTracker PVPWarnLogTrackerAvoid PVPWarnTestLog
 
 # constant values
 code/PVPW_Constants.lua

--- a/profiles/PVPW_Profile.lua
+++ b/profiles/PVPW_Profile.lua
@@ -88,6 +88,11 @@ end
   @param {string} profileName
 ]]--
 function me.CreateProfile(profileName)
+  if not profileName or profileName == "" then
+    mod.logger.LogWarn(me.tag, "CreateProfile called with invalid profile name")
+    return
+  end
+
   if #PVPWarnProfiles >= maxProfiles then
     mod.logger.PrintUserError(
       string.format(rgpvpw.L["user_message_add_new_profile_max_reached"], maxProfiles)
@@ -130,13 +135,8 @@ end
   @param {string} profileName
 ]]--
 function me.DeleteProfile(profileName)
-  if profileName == nil then
-    mod.logger.PrintUserError(rgpvpw.L["user_message_select_profile_before_delete"])
-    return
-  end
-
-  if profileName == RGPVPW_CONSTANTS.DEFAULT_PROFILE_NAME then
-    mod.logger.PrintUserError(rgpvpw.L["user_message_default_profile_cannot_be_deleted"])
+  if not profileName or profileName == "" then
+    mod.logger.LogWarn(me.tag, "DeleteProfile called with invalid profile name")
     return
   end
 
@@ -156,8 +156,8 @@ end
   @param {string} profileName
 ]]--
 function me.LoadProfile(profileName)
-  if profileName == nil then
-    mod.logger.PrintUserError(rgpvpw.L["user_message_select_profile_before_load"])
+  if not profileName or profileName == "" then
+    mod.logger.LogWarn(me.tag, "LoadProfile called with invalid profile name")
     return
   end
 
@@ -198,13 +198,8 @@ end
   @param {string} profileName
 ]]--
 function me.UpdateProfile(profileName)
-  if profileName == nil then
-    mod.logger.PrintUserError(rgpvpw.L["user_message_select_profile_before_update"])
-    return
-  end
-
-  if profileName == RGPVPW_CONSTANTS.DEFAULT_PROFILE_NAME then
-    mod.logger.PrintUserError(rgpvpw.L["user_message_default_profile_cannot_be_modified"])
+  if not profileName or profileName == "" then
+    mod.logger.LogWarn(me.tag, "UpdateProfile called with invalid profile name")
     return
   end
 


### PR DESCRIPTION
This pull request improves the profile management system in the PVPWarn addon. The changes include introducing new utility functions for managing the selected profile, adding safeguards against invalid profile operations, and improving the user experience with clearer error messages.

### Profile selection and management improvements:
* Replaced the `currentSelectedProfile` variable with `currentSelectedProfileName` and added utility functions (`GetCurrentSelectedProfileName`, `SetCurrentSelectedProfileName`, and `ResetCurrentSelectedProfileName`) to handle profile selection more robustly. (`gui/PVPW_ProfileMenu.lua` - [gui/PVPW_ProfileMenu.luaL41-R74](diffhunk://#diff-35ea501a6c126a6004d3f33d91b11464337e7688e17dc67556f5e4bce9842deaL41-R74))
* Introduced the `ClearSelectedProfile` function to reset the selected profile and clear the highlight of the selected row. (`gui/PVPW_ProfileMenu.lua` - [gui/PVPW_ProfileMenu.luaR423-R431](diffhunk://#diff-35ea501a6c126a6004d3f33d91b11464337e7688e17dc67556f5e4bce9842deaR423-R431))
* Updated `ProfileListCellOnClick` to ensure only valid profiles can be selected. (`gui/PVPW_ProfileMenu.lua` - [gui/PVPW_ProfileMenu.luaL365-R411](diffhunk://#diff-35ea501a6c126a6004d3f33d91b11464337e7688e17dc67556f5e4bce9842deaL365-R411))

### UI improvements:
* Fixed an issue in `ProfileListUpdateOnUpdate` where rows without valid profiles were shown; these rows are now hidden. (`gui/PVPW_ProfileMenu.lua` - [gui/PVPW_ProfileMenu.luaR386-L354](diffhunk://#diff-35ea501a6c126a6004d3f33d91b11464337e7688e17dc67556f5e4bce9842deaR386-L354))
