### PR TITLE
 Add upgrade path to v2.0.0 with profile version checking

### DIFF
--- a/code/PVPW_Configuration.lua
+++ b/code/PVPW_Configuration.lua
@@ -136,6 +136,7 @@ end
 ]]--
 function me.MigrationPath()
   me.UpgradeToV1_1_2()
+  me.UpgradeToV2_0_0()
 end
 
 --[[
@@ -174,6 +175,66 @@ function me.UpgradeToV1_1_2()
   end
 
   mod.logger.LogDebug(me.tag, "Finished upgrade path from " .. PVPWarnConfiguration.addonVersion .. " to v1.1.2")
+end
+
+--[[
+  Should be run by versions: All < v2.0.0
+  Description: Profiles structure changed significantly in v2.0.0. This upgrade path checks all
+  existing profiles and if any have an old version (or no version), all profiles are reset
+  to ensure consistency with the new structure.
+]]--
+function me.UpgradeToV2_0_0()
+  local versions = {"v1.1.11", "v1.2.0", "v1.2.1", "v1.2.2", "v1.2.3", "v1.2.4", "v1.2.5", "v1.2.6", "v1.2.7", "v1.2.8"}
+  local shouldRunUpgradePath = false
+
+  for _, version in pairs(versions) do
+    if PVPWarnConfiguration.addonVersion == version then
+      shouldRunUpgradePath = true
+      break
+    end
+  end
+
+  if not shouldRunUpgradePath then return end
+
+  mod.logger.LogDebug(me.tag, "Running upgrade path from " .. PVPWarnConfiguration.addonVersion .. " to v2.0.0")
+
+  -- Check if profiles exist and need to be upgraded
+  if PVPWarnProfiles then
+    local needsProfileUpgrade = false
+    
+    -- Check each profile's version
+    for i = 1, #PVPWarnProfiles do
+      local profile = PVPWarnProfiles[i]
+      
+      -- If profile has no version field, it needs upgrade
+      if not profile.version then
+        needsProfileUpgrade = true
+        mod.logger.LogDebug(me.tag, "Found profile without version field: " .. (profile.name or "unnamed"))
+        break
+      end
+      
+      -- Check if profile version is one of the old versions
+      for _, oldVersion in pairs(versions) do
+        if profile.version == oldVersion then
+          needsProfileUpgrade = true
+          mod.logger.LogDebug(me.tag, "Found profile with old version: " .. profile.name .. " - " .. profile.version)
+          break
+        end
+      end
+      
+      if needsProfileUpgrade then break end
+    end
+    
+    -- If any profile needs upgrade, reinitialize all profiles
+    if needsProfileUpgrade then
+      mod.logger.LogInfo(me.tag, "Profiles need upgrade - reinitializing with default profile")
+      mod.profile.InitializeDefaultProfile()
+      -- Inform the user about the profile reset
+      print("|cFF00FFB0" .. RGPVPW_CONSTANTS.ADDON_NAME .. ":|r " .. rgpvpw.L["user_message_profiles_reset_for_upgrade"])
+    end
+  end
+
+  mod.logger.LogDebug(me.tag, "Finished upgrade path from " .. PVPWarnConfiguration.addonVersion .. " to v2.0.0")
 end
 
 --[[

--- a/code/PVPW_Configuration.lua
+++ b/code/PVPW_Configuration.lua
@@ -201,18 +201,18 @@ function me.UpgradeToV2_0_0()
   -- Check if profiles exist and need to be upgraded
   if PVPWarnProfiles then
     local needsProfileUpgrade = false
-    
+
     -- Check each profile's version
     for i = 1, #PVPWarnProfiles do
       local profile = PVPWarnProfiles[i]
-      
+
       -- If profile has no version field, it needs upgrade
       if not profile.version then
         needsProfileUpgrade = true
         mod.logger.LogDebug(me.tag, "Found profile without version field: " .. (profile.name or "unnamed"))
         break
       end
-      
+
       -- Check if profile version is one of the old versions
       for _, oldVersion in pairs(versions) do
         if profile.version == oldVersion then
@@ -221,16 +221,17 @@ function me.UpgradeToV2_0_0()
           break
         end
       end
-      
+
       if needsProfileUpgrade then break end
     end
-    
+
     -- If any profile needs upgrade, reinitialize all profiles
     if needsProfileUpgrade then
       mod.logger.LogInfo(me.tag, "Profiles need upgrade - reinitializing with default profile")
       mod.profile.InitializeDefaultProfile()
       -- Inform the user about the profile reset
-      print("|cFF00FFB0" .. RGPVPW_CONSTANTS.ADDON_NAME .. ":|r " .. rgpvpw.L["user_message_profiles_reset_for_upgrade"])
+      print("|cFF00FFB0" .. RGPVPW_CONSTANTS.ADDON_NAME .. ":|r "
+        .. rgpvpw.L["user_message_profiles_reset_for_upgrade"])
     end
   end
 

--- a/localization/deDE.lua
+++ b/localization/deDE.lua
@@ -102,6 +102,7 @@ if (GetLocale() == "deDE") then
     .. "Du hast das maximum erreicht"
   rgpvpw.L["user_message_default_profile_cannot_be_deleted"] = "Das Standard Profil kann nicht gelöscht werden"
   rgpvpw.L["user_message_default_profile_cannot_be_modified"] = "Das Standard Profil kann nicht verändert werden"
+  rgpvpw.L["user_message_profiles_reset_for_upgrade"] = "Deine Profile wurden aufgrund des Upgrades auf v2.0.0 auf die Standardeinstellungen zurückgesetzt."
 
   -- categories
   rgpvpw.L["category_druid"] = "Druide"

--- a/localization/deDE.lua
+++ b/localization/deDE.lua
@@ -102,7 +102,8 @@ if (GetLocale() == "deDE") then
     .. "Du hast das maximum erreicht"
   rgpvpw.L["user_message_default_profile_cannot_be_deleted"] = "Das Standard Profil kann nicht gelöscht werden"
   rgpvpw.L["user_message_default_profile_cannot_be_modified"] = "Das Standard Profil kann nicht verändert werden"
-  rgpvpw.L["user_message_profiles_reset_for_upgrade"] = "Deine Profile wurden aufgrund des Upgrades auf v2.0.0 auf die Standardeinstellungen zurückgesetzt."
+  rgpvpw.L["user_message_profiles_reset_for_upgrade"] = "Deine Profile wurden aufgrund des Upgrades auf v2.0.0 auf die "
+    .. "Standardeinstellungen zurückgesetzt."
 
   -- categories
   rgpvpw.L["category_druid"] = "Druide"

--- a/localization/enUS.lua
+++ b/localization/enUS.lua
@@ -97,7 +97,8 @@ rgpvpw.L["user_message_select_profile_already_exists"] = "Profile already exist 
 rgpvpw.L["user_message_add_new_profile_max_reached"] = "A maximum of %s profiles is allowed you reached the maximum"
 rgpvpw.L["user_message_default_profile_cannot_be_deleted"] = "The default profile cannot be deleted"
 rgpvpw.L["user_message_default_profile_cannot_be_modified"] = "The default profile cannot be modified"
-rgpvpw.L["user_message_profiles_reset_for_upgrade"] = "Your profiles have been reset to default due to the upgrade to v2.0.0"
+rgpvpw.L["user_message_profiles_reset_for_upgrade"] = "Your profiles have been reset to default due to the upgrade "
+  .. "to v2.0.0"
 -- categories
 rgpvpw.L["category_druid"] = "Druid"
 rgpvpw.L["category_hunter"] = "Hunter"

--- a/localization/enUS.lua
+++ b/localization/enUS.lua
@@ -97,7 +97,7 @@ rgpvpw.L["user_message_select_profile_already_exists"] = "Profile already exist 
 rgpvpw.L["user_message_add_new_profile_max_reached"] = "A maximum of %s profiles is allowed you reached the maximum"
 rgpvpw.L["user_message_default_profile_cannot_be_deleted"] = "The default profile cannot be deleted"
 rgpvpw.L["user_message_default_profile_cannot_be_modified"] = "The default profile cannot be modified"
-
+rgpvpw.L["user_message_profiles_reset_for_upgrade"] = "Your profiles have been reset to default due to the upgrade to v2.0.0"
 -- categories
 rgpvpw.L["category_druid"] = "Druid"
 rgpvpw.L["category_hunter"] = "Hunter"


### PR DESCRIPTION
  - Implement UpgradeToV2_0_0 function that checks all profile versions
  - If any profile lacks version field or has version < v2.0.0, reset all profiles
  - Add user notification messages in English and German when profiles are reset
  - Update function documentation to reflect profile structure changes
  - Ensures clean migration to v2.0.0's new profile format