### PR TITLE
fix: correct typo in textureName reference in PVPW_Common.lua

### DIFF
--- a/code/PVPW_Common.lua
+++ b/code/PVPW_Common.lua
@@ -178,5 +178,5 @@ function me.GetTextureNameByValue(colorValue)
     end
   end
 
-  return RGPVPW_CONSTANTS.TEXTURES.none.texturName -- default if none was found
+  return RGPVPW_CONSTANTS.TEXTURES.none.textureName -- default if none was found
 end


### PR DESCRIPTION
Fix typo in GetTextureNameByValue function